### PR TITLE
refactor(UNT-T12289): reaction popup functioning update

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,20 @@ export default const App = () => {
 
 #### Usage
 
+```jsx
+
+const ReactionItem = () => {
+  const [selectedEmoji, setSelectedEmoji] = useState();
+    return (
+      <View>
+        <Reaction items={ReactionItems} onTap={setSelectedEmoji}>
+          <Text>{selectedEmoji ? selectedEmoji?.emoji : 'Like'}</Text>
+        </Reaction>
+      </View>
+    )
+}
+
+```
 ---
 ##### App.tsx
  Use the above [App](#app) example but the only change here is to wrap the root component with ReactionProvider.
@@ -291,7 +305,7 @@ import { ReactionProvider } from 'react-native-reactions';
 |type               | default                        | string   | Different type of component like default and modal |
 |items              | [ReactionItems](#reactionitems)| array    | Array of reaction emojis |
 |disabled           | false                          | boolean  | If true, disable all interactions for this component  |
-|showPopupType    | default                        | string   | Pressable showPopupType like default, onPress and onLongPress<br />-  If showPopupType is default, then reaction popup will be shown on onPress and onLongPress both.<br /> - If showPopupType is onPress, then reaction popup will be shown on onPress only.<br /> - If showPopupType is onLongPress, then reaction popup will be shown on onLongPress only        |
+|showPopupType    | default                        | string   | Pressable showPopupType like default and onPress<br />-  If showPopupType is default, then reaction popup will be shown on onLongPress only<br /> - If showPopupType is onPress, then reaction popup will be shown on onPress only
 |onPress            | -                              | function | Callback function that triggers when the wrapped element is pressed  |
 |onLongPress        | -                              | function | Callback function that triggers when the wrapped element is long pressed |
 |onTap              | -                              | function | Callback function that returns selected emoji |

--- a/src/components/ReactionView/hooks/useReaction.ts
+++ b/src/components/ReactionView/hooks/useReaction.ts
@@ -35,13 +35,9 @@ const useReaction = (props: ReactionViewProps) => {
 
   const showTopEmojiCard: boolean = mainViewY < 150 ? true : false;
 
-  const isSinglePress =
-    showPopupType === GlobalConstants.onPress ||
-    showPopupType === GlobalConstants.default;
+  const isSinglePress = showPopupType === GlobalConstants.onPress;
 
-  const isLongPress =
-    showPopupType === GlobalConstants.onLongPress ||
-    showPopupType === GlobalConstants.default;
+  const isLongPress = showPopupType === GlobalConstants.default;
 
   return {
     currentEmoji,

--- a/src/components/ReactionView/types.ts
+++ b/src/components/ReactionView/types.ts
@@ -12,7 +12,7 @@ export interface ReactionViewProps extends emojiProps, EmojiAnimationProps {
   itemIndex?: number;
   onShowDismissCard?: (onShowDismissCardType?: boolean) => void;
   isShowCardInCenter?: boolean;
-  showPopupType?: 'default' | 'onPress' | 'onLongPress';
+  showPopupType?: 'default' | 'onPress';
   onPress?: () => void;
   disabled?: boolean;
   onLongPress?: () => void;


### PR DESCRIPTION
- Add basic usage code in readme File
- refactor showPopupType prop (If showPopupType is default, then reaction popup will be shown on onLongPress only and If showPopupType is onPress, then reaction popup will be shown on onPress only)