### PR TITLE
fix(EmojiItem/Hook): update animation range

### DIFF
--- a/src/components/EmojiItem/hooks/useEmojiItem.ts
+++ b/src/components/EmojiItem/hooks/useEmojiItem.ts
@@ -47,7 +47,7 @@ const useEmojiItem = (props: EmojiItemProps) => {
     setTitlePosition(e.nativeEvent.layout.x - 4);
   };
 
-  const reverseEnim = (scaleEmoji as any).value === 2 ? [2, 1, 0] : [0, 1, 2];
+  const reverseEnim = (scaleEmoji as any).value === 2 ? [2, 1, 1] : [1, 1, 2];
 
   useEffect(() => {
     scaleEmoji.value = withTiming(scaled ? 2 : 1, {


### PR DESCRIPTION
# **Issue**
The scale animation causes emojis to disappear momentarily while swiping between them.

# **Fix**
To fix the issue, I simply updated the animation range that is in the useEmojiItem. 

# **Results**
The issue has been resolved by modifying the animation range within the useEmojiItem hook.


**Before**

https://github.com/SimformSolutionsPvtLtd/react-native-reactions/assets/29506704/85723fd8-c4c9-4c8c-803a-8970e7d677ab


**After**


https://github.com/SimformSolutionsPvtLtd/react-native-reactions/assets/29506704/f509db63-4884-4d68-a68f-8f83f783d3ac


